### PR TITLE
Convert pipeline-employee-management to GitHub Actions

### DIFF
--- a/.github/workflows/pipeline-employee-management-1.yml
+++ b/.github/workflows/pipeline-employee-management-1.yml
@@ -1,0 +1,46 @@
+name: pipeline-employee-management-1
+on:
+  workflow_dispatch:
+jobs:
+  Build:
+    runs-on: ubuntu-latest
+    steps:
+    - name: checkout
+      uses: actions/checkout@v4.1.0
+#     # 'script' was not transformed because there is no suitable equivalent in GitHub Actions
+#     - name: script
+#       arguments:
+#       - key: scriptBlock
+#         value:
+#           isLiteral: true
+#           value: |-
+#             echo 'Building the application...'
+#                                 sh 'mvn clean package'
+  Test:
+    runs-on: ubuntu-latest
+    needs: Build
+    steps:
+    - name: checkout
+      uses: actions/checkout@v4.1.0
+#     # 'script' was not transformed because there is no suitable equivalent in GitHub Actions
+#     - name: script
+#       arguments:
+#       - key: scriptBlock
+#         value:
+#           isLiteral: true
+#           value: |-
+#             echo 'Running tests...'
+#                                 sh 'mvn test'
+  Deploy:
+    runs-on: ubuntu-latest
+    needs: Test
+    steps:
+    - name: checkout
+      uses: actions/checkout@v4.1.0
+#     # 'script' was not transformed because there is no suitable equivalent in GitHub Actions
+#     - name: script
+#       arguments:
+#       - key: scriptBlock
+#         value:
+#           isLiteral: true
+#           value: echo 'Deploying the application...'


### PR DESCRIPTION
Pipeline migrated from [Jenkins](https://e2bd-87-116-161-108.ngrok-free.app/job/pipeline-employee-management/) :tada:

## Manual steps

Perform the following steps to complete the migration:

### pipeline-employee-management-1
- [ ] Ensure build tool is available: `jdk`
- [ ] Ensure build tool is available: `maven`